### PR TITLE
Fix macOS settings path in README

### DIFF
--- a/crates/icy_term/README.md
+++ b/crates/icy_term/README.md
@@ -121,7 +121,7 @@ Available tools:
 Settings are stored in platform-specific locations:
 
 - **Linux**: `~/.config/icy_term/`
-- **macOS**: `~/Library/Application Support/icy_term/`
+- **macOS**: `~/Library/Application Support/com.GitHub.icy_term'`
 - **Windows**: `%APPDATA%\icy_term\`
 
 ## Contributing


### PR DESCRIPTION
wrong path was listed
tested with icy term 0.8.2