### PR TITLE
Bugfix OOM from DCS/Sixel macro-repeat sequence

### DIFF
--- a/crates/icy_parser_core/src/ansi/mod.rs
+++ b/crates/icy_parser_core/src/ansi/mod.rs
@@ -233,9 +233,7 @@ impl AnsiParser {
                 i += 1;
                 repeat_count = 0;
                 while i < data.len() && data[i].is_ascii_digit() {
-                    repeat_count = repeat_count
-                        .saturating_mul(10)
-                        .saturating_add((data[i] - b'0') as usize);
+                    repeat_count = repeat_count.wrapping_mul(10).wrapping_add((data[i] - b'0') as usize);
                     i += 1;
                 }
                 if repeat_count > MAX_REPEAT {

--- a/crates/icy_parser_core/src/ansi/mod.rs
+++ b/crates/icy_parser_core/src/ansi/mod.rs
@@ -225,6 +225,7 @@ impl AnsiParser {
         let mut repeat_count: usize = 0;
         let mut in_repeat = false;
         let mut repeat_start = 0;
+        const MAX_REPEAT: usize = 65536;
 
         while i < data.len() {
             if data[i] == b'!' {
@@ -232,8 +233,13 @@ impl AnsiParser {
                 i += 1;
                 repeat_count = 0;
                 while i < data.len() && data[i].is_ascii_digit() {
-                    repeat_count = repeat_count.wrapping_mul(10).wrapping_add((data[i] - b'0') as usize);
+                    repeat_count = repeat_count
+                        .saturating_mul(10)
+                        .saturating_add((data[i] - b'0') as usize);
                     i += 1;
+                }
+                if repeat_count > MAX_REPEAT {
+                    repeat_count = MAX_REPEAT;
                 }
                 if i < data.len() && data[i] == b';' {
                     i += 1;

--- a/crates/icy_parser_core/tests/ansi/dcs.rs
+++ b/crates/icy_parser_core/tests/ansi/dcs.rs
@@ -53,8 +53,6 @@ fn test_dcs_hex_macro_repeat_capped() {
         b"\x1bP0;0;1!z!18446744073709551615;41;\x1b\\",
         &mut sink,
     );
-    // Should complete without panicking. The macro is stored internally;
-    // no DeviceControlString is emitted for macro definitions.
 }
 
 #[test]

--- a/crates/icy_parser_core/tests/ansi/dcs.rs
+++ b/crates/icy_parser_core/tests/ansi/dcs.rs
@@ -43,6 +43,21 @@ fn test_dcs_sixel() {
 }
 
 #[test]
+fn test_dcs_hex_macro_repeat_capped() {
+    let mut parser = AnsiParser::new();
+    let mut sink = CollectSink::new();
+
+    // Macro definition (!z) with usize::MAX repeat in hex encoding.
+    // Without the cap this would allocate ~18 exabytes and OOM.
+    parser.parse(
+        b"\x1bP0;0;1!z!18446744073709551615;41;\x1b\\",
+        &mut sink,
+    );
+    // Should complete without panicking. The macro is stored internally;
+    // no DeviceControlString is emitted for macro definitions.
+}
+
+#[test]
 fn test_dcs_font_loading() {
     let mut parser = AnsiParser::new();
     let mut sink = CollectSink::new();


### PR DESCRIPTION
Caused by unbounded 'repeat_count', it is possible as described in `test_dcs_hex_macro_repeat_capped` for a 48-byte string to cause ~18 exabytes of memory to be allocated.

Example telnet server code to send payload,

```
echo -e 'BEGIN PAYLOAD:\033P0;0;1!z!18446744073709551615;41;\033\\ENDPAYOAD' |nc  -l 6023
```

https://github.com/user-attachments/assets/31327e0c-cc2b-4f28-aa88-d77157af302b

it kind of just crashes the terminal, the GUI is still available but it is unable to connect to any other system and memory usage keeps growing until kernel OOM killer is activated